### PR TITLE
Add fake simulation support for talonSRXCollection

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -19,7 +19,7 @@ Size=235,169
 Collapsed=0
 
 [Window][System Joysticks]
-Pos=29,345
+Pos=33,348
 Size=192,150
 Collapsed=0
 
@@ -59,7 +59,7 @@ Size=250,695
 Collapsed=0
 
 [Window][Joysticks]
-Pos=347,599
+Pos=346,598
 Size=796,73
 Collapsed=0
 
@@ -151,4 +151,10 @@ start=0
 
 [DriverStation][Main]
 disable=0
+
+[Device][TalonSRXCollection[1]]
+open=0
+
+[Device][TalonSRXCollection[3]]
+open=0
 

--- a/src/main/java/frc/lib5k/components/motors/TalonSRXCollection.java
+++ b/src/main/java/frc/lib5k/components/motors/TalonSRXCollection.java
@@ -5,6 +5,9 @@ import java.util.function.Consumer;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
+import edu.wpi.first.hal.SimBoolean;
+import edu.wpi.first.hal.SimDevice;
+import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
 
@@ -41,6 +44,11 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
 
     /* Telemetry */
     private NetworkTable telemetryTable;
+    private SimDevice m_simDevice;
+    private SimBoolean m_simConnected;
+    private SimBoolean m_simInverted;
+    private SimDouble m_simSpeed;
+
 
     public TalonSRXCollection(WPI_TalonSRX master, WPI_TalonSRX... slaves) {
         super(master, slaves);
@@ -65,11 +73,21 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
         // Get the telemetry NetworkTable
         telemetryTable = ComponentTelemetry.getInstance().getTableForComponent(name);
 
+        // handle simulation device settings
+        m_simDevice = SimDevice.create("TalonSRXCollection", master.getDeviceID());
+        if (m_simDevice != null) {
+            m_simConnected = m_simDevice.createBoolean("Connected", true, true);
+            m_simInverted = m_simDevice.createBoolean("Inverted", true, false);
+            m_simSpeed = m_simDevice.createDouble("Speed", true, 0.0);
+        }
+
+
     }
 
     @Override
     public void set(double speed) {
         output = speed;
+        m_simSpeed.set(speed);
 
         super.set(speed);
     }
@@ -85,6 +103,8 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
     @Override
     public void setInverted(boolean isInverted) {
         inverted = isInverted;
+        m_simInverted.set(isInverted);
+
         super.setInverted(isInverted);
 
     }

--- a/src/main/java/frc/lib5k/simulation/Hooks.java
+++ b/src/main/java/frc/lib5k/simulation/Hooks.java
@@ -74,4 +74,5 @@ public class Hooks {
         }
     }
 
+
 }


### PR DESCRIPTION
CTRE has yet to add HALSIM support for their devices. This PR will fake support for the TalonSRXCollection object, so we can simulate TalonSRX devices