### PR TITLE
Re-map shooter button to reduce confusion

### DIFF
--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -111,7 +111,7 @@ public class OI {
      * @return Should be shooting?
      */
     public boolean shouldShoot() {
-        return m_shouldShootToggle.feed(m_operatorController.getYButtonPressed());
+        return m_operatorController.getTriggerAxis(Hand.kRight) > 0.8;
     }
 
     /**
@@ -135,12 +135,6 @@ public class OI {
         }
     }
 
-    /**
-     * Reset the shooter input toggle
-     */
-    public void resetShooterInput() {
-        m_shouldShootToggle.reset();
-    }
 
     /**
      * Check if the robot should be intaking balls right now

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -135,7 +135,6 @@ public class OI {
         }
     }
 
-
     /**
      * Check if the robot should be intaking balls right now
      * 
@@ -150,6 +149,15 @@ public class OI {
      */
     public void resetIntakeInput() {
         m_shouldIntakeToggle.reset();
+    }
+
+    /**
+     * Should the cell counter be reset?
+     * 
+     * @return Should reset
+     */
+    public boolean shouldResetCellCount() {
+        return (m_operatorController.getPOV() == 90) && m_operatorController.getXButtonPressed();
     }
 
 }

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -29,6 +29,9 @@ public class OI {
     // Intake action toggle
     private Toggle m_shouldIntakeToggle = new Toggle();
 
+    // Unjam toggle
+    private Toggle m_shouldUnjamToggle = new Toggle();
+
     /**
      * Force the use of getInstance() by setting this class private
      */
@@ -158,6 +161,14 @@ public class OI {
      */
     public boolean shouldResetCellCount() {
         return (m_operatorController.getPOV() == 90) && m_operatorController.getXButtonPressed();
+    }
+
+    public boolean shouldUnjam() {
+        return m_shouldUnjamToggle.feed(m_operatorController.getBButtonPressed());
+    }
+
+    public void resetUnjamInput() {
+        m_shouldUnjamToggle.reset();
     }
 
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -18,6 +18,7 @@ import frc.robot.subsystems.CellSuperstructure;
 import frc.robot.subsystems.Climber;
 import frc.robot.subsystems.DriveTrain;
 import frc.robot.subsystems.PanelManipulator;
+import frc.robot.subsystems.cellmech.Hopper;
 import frc.robot.subsystems.cellmech.Intake;
 import frc.robot.vision.Limelight2;
 import frc.robot.vision.Limelight2.LEDMode;
@@ -147,6 +148,9 @@ public class Robot extends TimedRobot {
 
 		// Stow the superstructure
 		m_cellSuperstructure.stop();
+
+		// Force-set the hopper to recognize 3 power cells
+		Hopper.getInstance().forceCellCount(3);
 	}
 
 	@Override

--- a/src/main/java/frc/robot/RobotConstants.java
+++ b/src/main/java/frc/robot/RobotConstants.java
@@ -215,7 +215,7 @@ public class RobotConstants {
 
         public static final double ARM_TICKS_PER_DEGREE = 1000;
 
-        public static final double ARM_UP_SPEED = -0.85;
+        public static final double ARM_UP_SPEED = -0.9;
         public static final double ARM_DOWN_SPEED = 0.35; 
 
         public static final double ROLLER_SPEED = 0.8;

--- a/src/main/java/frc/robot/autonomous/actions/cells/UnjamCells.java
+++ b/src/main/java/frc/robot/autonomous/actions/cells/UnjamCells.java
@@ -16,4 +16,9 @@ public class UnjamCells extends CommandBase {
     public void initialize() {
         m_cellSuperstructure.unjam();
     }
+
+    @Override
+    public void end(boolean interrupted) {
+        m_cellSuperstructure.stop();
+    }
 }

--- a/src/main/java/frc/robot/commands/OperatorControl.java
+++ b/src/main/java/frc/robot/commands/OperatorControl.java
@@ -4,6 +4,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.OI;
 import frc.robot.autonomous.actions.cells.IntakeCells;
 import frc.robot.autonomous.actions.cells.ShootCells;
+import frc.robot.autonomous.actions.cells.UnjamCells;
 import frc.robot.subsystems.Climber;
 import frc.robot.subsystems.cellmech.Hopper;
 
@@ -15,6 +16,7 @@ public class OperatorControl extends CommandBase {
     /** sub-commands */
     private IntakeCells m_intakeCellsCommand = new IntakeCells(5);
     private ShootCells m_shootCellsCommand = new ShootCells(5);
+    private UnjamCells m_unjamCommend = new UnjamCells();
     private ClimbController m_climbController = new ClimbController();
 
     /** Instance of OI */
@@ -38,9 +40,13 @@ public class OperatorControl extends CommandBase {
 
             // Kill the intake command
             m_intakeCellsCommand.cancel();
+            m_unjamCommend.cancel();
 
             // Disable the intake toggle
             m_oi.resetIntakeInput();
+
+            // Stop the bot from unjamming
+            m_oi.resetUnjamInput();
         } else {
             m_shootCellsCommand.cancel();
         }
@@ -53,6 +59,10 @@ public class OperatorControl extends CommandBase {
 
             // Kill the shooting command (intake gets priority)
             m_shootCellsCommand.cancel();
+            m_unjamCommend.cancel();
+
+            // Stop the bot from unjamming
+            m_oi.resetUnjamInput();
 
         } else {
             m_intakeCellsCommand.cancel();
@@ -68,6 +78,18 @@ public class OperatorControl extends CommandBase {
         // Check if the cell counter should be reset
         if (m_oi.shouldResetCellCount()) {
             Hopper.getInstance().forceCellCount(0);
+        }
+
+        if (m_oi.shouldUnjam()) {
+
+            // Stop any other action
+            m_oi.resetIntakeInput();
+
+            // Start the un-jammer
+            m_unjamCommend.schedule();
+
+        } else {
+            m_unjamCommend.cancel();
         }
 
     }

--- a/src/main/java/frc/robot/commands/OperatorControl.java
+++ b/src/main/java/frc/robot/commands/OperatorControl.java
@@ -21,7 +21,7 @@ public class OperatorControl extends CommandBase {
 
     @Override
     public void initialize() {
-        
+
         // Lock the climber
         Climber.getInstance().lock();
     }
@@ -53,8 +53,6 @@ public class OperatorControl extends CommandBase {
             // Kill the shooting command (intake gets priority)
             m_shootCellsCommand.cancel();
 
-            // Disable the shooter toggle
-            m_oi.resetShooterInput();
         } else {
             m_intakeCellsCommand.cancel();
         }

--- a/src/main/java/frc/robot/commands/OperatorControl.java
+++ b/src/main/java/frc/robot/commands/OperatorControl.java
@@ -5,6 +5,7 @@ import frc.robot.OI;
 import frc.robot.autonomous.actions.cells.IntakeCells;
 import frc.robot.autonomous.actions.cells.ShootCells;
 import frc.robot.subsystems.Climber;
+import frc.robot.subsystems.cellmech.Hopper;
 
 /**
  * Test code for the intake/shooter superstructure. This will be replaced soon
@@ -62,6 +63,11 @@ public class OperatorControl extends CommandBase {
             m_climbController.schedule();
         } else if (m_oi.shouldCancelClimb()) {
             m_climbController.cancel();
+        }
+
+        // Check if the cell counter should be reset
+        if (m_oi.shouldResetCellCount()) {
+            Hopper.getInstance().forceCellCount(0);
         }
 
     }

--- a/src/main/java/frc/robot/subsystems/CellSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/CellSuperstructure.java
@@ -162,7 +162,7 @@ public class CellSuperstructure extends SubsystemBase {
 
             m_intake.stow();
 
-            m_shooter.setOutputPercent(0.7);
+            m_shooter.setOutputPercent(0.85);
 
         } else {
             // stop everything once hopper has desired amount of cells or no cells

--- a/src/main/java/frc/robot/subsystems/cellmech/Hopper.java
+++ b/src/main/java/frc/robot/subsystems/cellmech/Hopper.java
@@ -6,6 +6,7 @@ import frc.lib5k.components.motors.motorsensors.TalonEncoder;
 import frc.lib5k.components.sensors.EncoderBase;
 import frc.lib5k.components.sensors.LineBreak;
 import frc.lib5k.simulation.wrappers.SimTalon;
+import frc.lib5k.utils.Mathutils;
 import frc.lib5k.utils.RobotLogger;
 import frc.robot.RobotConstants;
 
@@ -267,7 +268,7 @@ public class Hopper extends SubsystemBase {
         }
 
         // if belt has gone 12 inches, stop tying and set state to ready to intake
-        if (m_ticksAtStartOfIntake - m_hopperEncoder.getTicks()  >= 41583) {
+        if (m_ticksAtStartOfIntake - m_hopperEncoder.getTicks() >= 41583) {
             m_systemState = SystemState.INTAKEREADY;
         }
     }
@@ -454,6 +455,16 @@ public class Hopper extends SubsystemBase {
      */
     public void manuallyControlBelt(double speed) {
         m_hopperBelt.set(speed);
+    }
+
+    /**
+     * Force-override the internal power cell counter
+     * 
+     * @param count New cell count [0-5]
+     */
+    public void forceCellCount(int count) {
+        logger.log("Hopper", String.format("Cell count force-set to: %d", count));
+        m_cellCount = (int) Mathutils.clamp(count, 0, 5);
     }
 
 }

--- a/src/main/java/frc/robot/subsystems/cellmech/Intake.java
+++ b/src/main/java/frc/robot/subsystems/cellmech/Intake.java
@@ -181,11 +181,14 @@ public class Intake extends SubsystemBase {
             // Ensure our roller is stopped before arm deployment
             setRollerSpeed(0.0);
 
+            setArmSpeed(0.0);
+
+
         }
 
         // As long as we are not at our deployed position, lower the arms
-        if (getArmPosition() != ArmPosition.DEPLOYED) {
-            setArmSpeed(RobotConstants.Intake.ARM_DOWN_SPEED);
+        if (getArmPosition() != ArmPosition.STOWED) {
+            setArmSpeed(RobotConstants.Intake.ARM_UP_SPEED);
         } else {
             // Stop the arms
             setArmSpeed(0.0);


### PR DESCRIPTION
I have a habit of shooting when I am trying to intake. This PR makes shooting require the operator to hold the right trigger. This should remove the mix-up