### PR TITLE
Add runner script to start robot simulation on linux systems

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -84,7 +84,7 @@ Size=148,123
 Collapsed=0
 
 [Window][2D Field View]
-Pos=332,579
+Pos=299,434
 Size=706,387
 Collapsed=0
 

--- a/run-simulation.sh
+++ b/run-simulation.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+# Spawn HALSIM
+./gradlew simulateJava
+task_pid=$(cat build/pids/simulateJava.pid)
+
+# Spawn a tail follower
+tail -f build/stdout/simulateJava.log & tail_pid=$!
+
+while [ 1 ]
+do
+    # -0 is a special "poke" signal - "are you around?"
+    kill -0 $task_pid
+    if [ $? -eq 0 ]
+    then
+        # Original task is still alive.
+        sleep 2
+        continue
+    fi
+    kill -TERM $tail_pid
+    break
+done


### PR DESCRIPTION
This lets us simulate the robot without VSCode. (Yay for vim users!)