### PR TITLE
Let autonomous paths force-set the shooter velocity

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -60,7 +60,7 @@ Collapsed=0
 
 [Window][Joysticks]
 Pos=287,315
-Size=796,240
+Size=796,73
 Collapsed=0
 
 [Window][PDP]
@@ -166,10 +166,6 @@ columns=10
 serpentine=0
 order=0
 start=0
-
-[Joystick][0]
-useGamepad=1
-guid=030000005e040000d102000001010000
 
 [DriverStation][Main]
 disable=0

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -22,6 +22,7 @@ import frc.robot.subsystems.DriveTrain;
 import frc.robot.subsystems.PanelManipulator;
 import frc.robot.subsystems.cellmech.Hopper;
 import frc.robot.subsystems.cellmech.Intake;
+import frc.robot.subsystems.cellmech.Shooter;
 import frc.robot.vision.Limelight2;
 import frc.robot.vision.Limelight2.CameraMode;
 import frc.robot.vision.Limelight2.LEDMode;
@@ -195,6 +196,9 @@ public class Robot extends TimedRobot {
 		// Put the limelight in "Secondary" mode for driver assist
 		Limelight2.getInstance().setCamMode(CameraMode.PIP_SECONDARY);
 		Limelight2.getInstance().setLED(LEDMode.OFF);
+
+		// Reset the shooter fallback velocity from possible modifications during autonomous
+		Shooter.getInstance().setFallbackVelocity(RobotConstants.Shooter.DEFAULT_VELOCITY);
 
 		// Disable the autonomous command
 		if (m_autonomousCommand != null) {

--- a/src/main/java/frc/robot/RobotConstants.java
+++ b/src/main/java/frc/robot/RobotConstants.java
@@ -308,7 +308,7 @@ public class RobotConstants {
         public static final double RPM_PER_METER = 1 / WHEEL_CIRCUMFERENCE;
         public static final double RPM_PER_MPS = RPM_PER_METER / 60;
 
-        public static final double DEFAULT_VELOCITY = MOTOR_MAX_RPM * 0.77;
+        public static final double DEFAULT_VELOCITY = MOTOR_MAX_RPM * 0.72;
 
     }
 

--- a/src/main/java/frc/robot/autonomous/actions/cells/ShootCells.java
+++ b/src/main/java/frc/robot/autonomous/actions/cells/ShootCells.java
@@ -32,7 +32,6 @@ public class ShootCells extends CommandBase {
         // if(m_shooter.isInPosition()){
         RobotLogger.getInstance().log("ShootCells", String.format("Shooting %d cells", m_shootAmount));
         m_cellSuperstructure.shootCells(m_shootAmount);
-        // }
     }
 
     @Override

--- a/src/main/java/frc/robot/autonomous/paths/score/ScoreTwice.java
+++ b/src/main/java/frc/robot/autonomous/paths/score/ScoreTwice.java
@@ -4,16 +4,18 @@ import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib5k.kinematics.purepursuit.Path;
+import frc.robot.RobotConstants;
 import frc.robot.autonomous.AutonomousStartpoints;
 import frc.robot.autonomous.actions.DrivePath;
 import frc.robot.autonomous.actions.TurnToCommand;
-import frc.robot.autonomous.actions.VisionAlign;
 import frc.robot.autonomous.actions.cells.IntakeCells;
 import frc.robot.autonomous.actions.cells.ShootCells;
 import frc.robot.autonomous.paths.AutonomousPath;
+import frc.robot.subsystems.cellmech.Shooter;
 
 public class ScoreTwice extends AutonomousPath {
 
@@ -33,25 +35,28 @@ public class ScoreTwice extends AutonomousPath {
         // Aim at goal
         output.addCommands(new TurnToCommand(Rotation2d.fromDegrees(150), 8.0));
 
-        // // Shoot 3 balls
+        // Config shooter fallback
+        output.addCommands(new InstantCommand(() -> {
+            Shooter.getInstance().setFallbackVelocity(RobotConstants.Shooter.MOTOR_MAX_RPM * 0.74);
+        }));
+
+        // Shoot 3 balls
         output.addCommands(new ShootCells(3).withTimeout(3.5));
 
         // Turn to trench
         output.addCommands(new TurnToCommand(Rotation2d.fromDegrees(0), 8.0));
 
-        // output.addCommands(new DrivePath(new Path(getStartingPose().getTranslation(), new Translation2d(startx + 0.5,starty)),  0.2,
-        // new Translation2d(0.2, 0.2), 0.025, 0.2));
-
         // Intake balls
         CommandBase intakeCommand = new IntakeCells(2);
 
+        // Get to the start of the trench
         DrivePath preTrench = new DrivePath(
-            new Path(new Translation2d(startx, starty), new Translation2d(startx + 0.4, starty)), 0.2,
-            new Translation2d(0.2, 0.2), 0.025, 0.5);
+                new Path(new Translation2d(startx, starty), new Translation2d(startx + 0.4, starty)), 0.2,
+                new Translation2d(0.2, 0.2), 0.025, 0.5);
 
         // Get through the trench
         DrivePath trenchMovement = new DrivePath(
-                new Path(new Translation2d(startx+0.2, starty), new Translation2d(startx + 1.1, starty)), 0.2,
+                new Path(new Translation2d(startx + 0.2, starty), new Translation2d(startx + 1.1, starty)), 0.2,
                 new Translation2d(0.2, 0.2), 0.025, 0.25);
 
         // Race the intake
@@ -59,11 +64,17 @@ public class ScoreTwice extends AutonomousPath {
 
         // // PPS Turn
         // output.addCommands(new DrivePath(
-        //         new Path(new Translation2d(startx + 2.0, starty), new Translation2d(startx + 2.1, starty + 0.4)), 0.2,
-        //         new Translation2d(0.2, 0.2), 0.2, 0.15));
+        // new Path(new Translation2d(startx + 2.0, starty), new Translation2d(startx +
+        // 2.1, starty + 0.4)), 0.2,
+        // new Translation2d(0.2, 0.2), 0.2, 0.15));
 
-        // // Face the target
+        // Face the target
         output.addCommands(new TurnToCommand(Rotation2d.fromDegrees(165), 8.0));
+
+        // Config shooter fallback
+        output.addCommands(new InstantCommand(() -> {
+            Shooter.getInstance().setFallbackVelocity(RobotConstants.Shooter.MOTOR_MAX_RPM * 0.83);
+        }));
 
         // Shoot 3 balls
         output.addCommands(new ShootCells(2).withTimeout(3.0));

--- a/src/main/java/frc/robot/subsystems/cellmech/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/cellmech/Shooter.java
@@ -70,6 +70,9 @@ public class Shooter extends SubsystemBase {
     // Telemetry object for tuning the flywheel
     private FlywheelTuner m_tuner;
 
+    // Fallback velocity for case of no vision targets found
+    private double m_fallbackVelocity = RobotConstants.Shooter.DEFAULT_VELOCITY;
+
     private Shooter() {
 
         // Create Limelight
@@ -296,6 +299,11 @@ public class Shooter extends SubsystemBase {
 
     }
 
+    public void setFallbackVelocity(double velocity) {
+        logger.log("Shooter", String.format("Fallback velocity set to: %.1f", velocity));
+        m_fallbackVelocity = velocity;
+    }
+
     public void setOutputPercent(double val) {
 
         // Switch to "Spin Up" mode. If we are already at, or above the setpoint, it
@@ -370,11 +378,11 @@ public class Shooter extends SubsystemBase {
 
         // If there is no target found, default to a constant shooting point
         if (!m_limelight.hasTarget()) {
-            return RobotConstants.Shooter.DEFAULT_VELOCITY;
+            return m_fallbackVelocity;
         }
 
         // TODO: Temp
-        return RobotConstants.Shooter.DEFAULT_VELOCITY;
+        return m_fallbackVelocity;
 
         // // Get distance to target
         // double angleToTarget = m_limelight.getTarget().ty;


### PR DESCRIPTION
We can now use `Shooter.getInstance().setFallbackVelocity()` to set the shooter fallback